### PR TITLE
[#23] Show rating of non-native builds on games with native support

### DIFF
--- a/src/content/steamapp.js
+++ b/src/content/steamapp.js
@@ -1,27 +1,24 @@
 "use strict";
 
 // Insert the ProtonDB rating below DEVELOPER/PUBLISHER
-function insert_rating(rating) {
+function insert_rating(rating, native_support) {
     var element = document.querySelector(".user_reviews");
     var subtitle = document.createElement("div");
     subtitle.className = "subtitle column'";
-    subtitle.textContent = "ProtonDB Rating:";
+    subtitle.textContent = "ProtonDB Rating".concat(native_support ? " (non-native):" : ":");
     var container = ProtonDB.get_rating_container(rating, "steam_row");
     container.prepend(subtitle);
-
     if (element) {
         element.append(container);
     }
 }
 
-if (document.querySelector("span.platform_img.linux") === null) {
-    var appid = Steam.get_app_id(window.location.href);
+var appid = Steam.get_app_id(window.location.href);
 
-    ProtonDB.request_rating(appid, (rating) => {
-        if (rating == "pending") {
-            insert_rating("Awaiting reports!");
-        } else {
-            insert_rating(rating);
-        }
-    });
-}
+ProtonDB.request_rating(appid, (rating) => {
+    if (rating == "pending") {
+        insert_rating("Awaiting reports!");
+    } else {
+        insert_rating(rating, document.querySelector("span.platform_img.linux") !== null);
+    }
+});


### PR DESCRIPTION
## Related Issue: 
* #23 

## Changes:
* Ratings on the non-native builds of games with native support are being displayed with the addition of "(non-native)" in the subtitle.

## Tested on:
| Browser | Tested | Version | Working |
|:-------:|:------:|:-------:|:-------:|
| Firefox | Yes  | 72.0.2    | Yes  |
| Chrome  | No |    ?    | ? |


