### PR TITLE
Fixes a bug where ratings were mismatched with their rows

### DIFF
--- a/src/js/wishlist.js
+++ b/src/js/wishlist.js
@@ -33,7 +33,7 @@ class Wishlist {
     
     static load_ratings() {
         const rows = document.getElementById('wishlist_ctn');
-        for (var row of rows.getElementsByClassName('wishlist_row')) {
+        for (const row of rows.getElementsByClassName('wishlist_row')) {
             const app_id = row.getAttribute('data-app-id');
             const stats_container = row.querySelector('.stats');
     


### PR DESCRIPTION
## Changes:
* Changes the variable type of the the wish list row for loop from `var` to `const`

## Tested on:
| Browser | Tested | Version | Working |
|:-------:|:------:|:-------:|:-------:|
| Firefox | Yes |    85    | Yes  |
| Chrome  | No |    ?    | ?  |

## Additional Notes

I noticed an intermittent issue where the incorrect ratings were being assigned to rows in the wish list. I believe this was caused by the outer scope of the for loop mutating the row variable which was visible to the inner scope of the ProtonDB callback. The issue was intermittent but after testing several times I was unable to reproduce the issue with this change.

If you have more experience with JavaScript perhaps you could comment and let me know if my hypothesis is correct. Sorry for having to push a bug fix so quickly after the new version of the extension was published.