### PR TITLE
Wishlist: Get Rating After Checking If Exists

### DIFF
--- a/src/js/wishlist.js
+++ b/src/js/wishlist.js
@@ -1,14 +1,14 @@
 "use strict";
 
 async function insertRating(row) {
-  const appid = row.getAttribute("data-app-id");
-  const rating = await getRatingElement(appid);
-
   const statsContainer = row.querySelector(".stats");
 
   if (statsContainer.querySelector(".protondb_rating_link")) {
     return true;
   }
+
+  const appid = row.getAttribute("data-app-id");
+  const rating = await getRatingElement(appid);
 
   const label = document.createElement("div");
   const value = document.createElement("div");
@@ -27,7 +27,7 @@ function insertRatings() {
   const rows = document.getElementById("wishlist_ctn");
 
   for (const row of rows.getElementsByClassName("wishlist_row")) {
-    insertRating(row)
+    insertRating(row);
   }
 
   setTimeout(insertRatings, 1000);


### PR DESCRIPTION
Don't get the rating from until after checking if we should bail when rating is already inserted.

This prevents unneeded api calls to ProtonDB.